### PR TITLE
Create wait-for-path@.service

### DIFF
--- a/systemd/system/wait-for-path@.service
+++ b/systemd/system/wait-for-path@.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Wait for '%I'
+
+[Service]
+TimeoutStartSec=infinity
+ExecStartPre=/bin/sh -c 'while [ ! -e %I ]; do /bin/sleep 10; done'
+ExecStart=/bin/echo 'Found %I'
+RemainAfterExit=yes


### PR DESCRIPTION
This is handy if you have network-ish paths (sshfs, zfs) which aren't guaranteed to be available at a specific time but need services to wait for them.