### PR TITLE
Wait for host

### DIFF
--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -1,7 +1,7 @@
 # See https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples:-patterns
 
 # stackexchange -- https://stackexchange.com/feeds/sites
-\b(?:askubuntu|serverfault|stack(?:exchange|overflow)|superuser).com/questions/\d+/[a-z-]+
+\b(?:askubuntu|serverfault|stack(?:exchange|overflow)|superuser).com/(?:questions/\d+/[a-z-]+|a/)
 
 # acceptable duplicates
 \s(long|LONG) \g{-1}\s

--- a/.github/actions/spelling/patterns.txt
+++ b/.github/actions/spelling/patterns.txt
@@ -1,5 +1,8 @@
 # See https://github.com/check-spelling/check-spelling/wiki/Configuration-Examples:-patterns
 
+# stackexchange -- https://stackexchange.com/feeds/sites
+\b(?:askubuntu|serverfault|stack(?:exchange|overflow)|superuser).com/questions/\d+/[a-z-]+
+
 # acceptable duplicates
 \s(long|LONG) \g{-1}\s
 \@param\s+(\w+)\s+\g{-1}\s

--- a/systemd/system/wait-for-host@.service
+++ b/systemd/system/wait-for-host@.service
@@ -1,0 +1,7 @@
+[Unit]
+After=network-online.target
+Wants=network-online.target
+# https://serverfault.com/questions/867830/systemd-start-service-only-after-dns-is-available
+# https://serverfault.com/a/867845
+[Service]
+ExecStart=/bin/sh -c "until host %I > /dev/null 2> /dev/null; do sleep 1; done"


### PR DESCRIPTION
Sometimes a service needs dns to be functional. It's possible to have "some networking", but not "functional dns".

For even more excitement, it's possible for one to need access to a host over a vpn, so if the vpn isn't up, the host isn't reachable.

This would enable a service to wait for the host to be "dns accessible".

It's of course possible to make a variant that requires "ping accessible", but that wasn't necessary for my use case.